### PR TITLE
Create PAPI placeholders for spawners

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -17,6 +17,11 @@
       <option name="url" value="https://hub.spigotmc.org/nexus/content/repositories/snapshots/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="PlaceholderAPI" />
+      <option name="name" value="PlaceholderAPI" />
+      <option name="url" value="https://repo.extendedclip.com/content/repositories/placeholderapi/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="central" />
       <option name="name" value="Maven Central repository" />
       <option name="url" value="https://repo1.maven.org/maven2" />

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -57,6 +57,10 @@
       <id>CodeMC</id>
       <url>https://repo.codemc.org/repository/maven-public</url>
     </repository>
+    <repository>
+      <id>PlaceholderAPI</id>
+      <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+    </repository>
   </repositories>
   <dependencies>
     <dependency>
@@ -104,6 +108,18 @@
       <artifactId>HeadDatabase-API</artifactId>
       <version>1.3.1</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>me.clip</groupId>
+      <artifactId>placeholderapi</artifactId>
+      <version>2.10.10</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>annotations</artifactId>
+          <groupId>org.jetbrains</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>PlaceholderAPI</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -102,6 +106,13 @@
             <version>2.2.0</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/resources/SilkSpawners_v2.jar</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.10.10</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/me/bestem0r/spawnercollectors/SCPlugin.java
+++ b/src/main/java/me/bestem0r/spawnercollectors/SCPlugin.java
@@ -8,6 +8,7 @@ import me.bestem0r.spawnercollectors.listener.BlockListener;
 import me.bestem0r.spawnercollectors.listener.JoinListener;
 import me.bestem0r.spawnercollectors.listener.QuitListener;
 import me.bestem0r.spawnercollectors.loot.LootManager;
+import me.bestem0r.spawnercollectors.placeholders.PlaceholderAPIExpansion;
 import me.bestem0r.spawnercollectors.utils.SpawnerUtils;
 import net.bestemor.core.CorePlugin;
 import net.bestemor.core.command.CommandModule;
@@ -69,6 +70,7 @@ public final class SCPlugin extends CorePlugin {
 
         this.lootManager = new LootManager(this);
         setupEconomy();
+        setupPlaceholders();
         loadValues();
 
         if (storeMethod == MYSQL) {
@@ -264,6 +266,14 @@ public final class SCPlugin extends CorePlugin {
             Bukkit.getLogger().info("Could not find Economy Provider!");
         }
 
+    }
+    /** Setup PlaceholderAPI integration */
+    private void setupPlaceholders() {
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new PlaceholderAPIExpansion(this).register();
+        } else {
+            Bukkit.getLogger().info("Could not find PlaceholderAPI!");
+        }
     }
 
     //Getters

--- a/src/main/java/me/bestem0r/spawnercollectors/collector/Collector.java
+++ b/src/main/java/me/bestem0r/spawnercollectors/collector/Collector.java
@@ -113,14 +113,7 @@ public class Collector {
 
         int max = 0;
         if (player != null) {
-            max = this.owner.getEffectivePermissions().stream()
-                    .map(PermissionAttachmentInfo::getPermission)
-                    .filter((s) -> s.startsWith("spawnercollectors.spawner." + type.name().toLowerCase() + "."))
-                    .filter((s) -> s.length() > 26 + type.name().length() + 1)
-                    .map((s) -> s.substring(26 + type.name().length() + 1))
-                    .mapToInt(Integer::parseInt)
-                    .max()
-                    .orElse(0);
+            max = SpawnerUtils.getMaxSpawners(this.owner, type);
         }
 
         //Check if amount is exceeding per-mob permission limit

--- a/src/main/java/me/bestem0r/spawnercollectors/placeholders/PlaceholderAPIExpansion.java
+++ b/src/main/java/me/bestem0r/spawnercollectors/placeholders/PlaceholderAPIExpansion.java
@@ -34,7 +34,7 @@ public class PlaceholderAPIExpansion extends PlaceholderExpansion {
 
     @Override
     public String getAuthor() {
-        return "bestem0r";
+        return "Bestem0r";
     }
 
     @Override

--- a/src/main/java/me/bestem0r/spawnercollectors/placeholders/PlaceholderAPIExpansion.java
+++ b/src/main/java/me/bestem0r/spawnercollectors/placeholders/PlaceholderAPIExpansion.java
@@ -1,0 +1,84 @@
+package me.bestem0r.spawnercollectors.placeholders;
+
+import me.bestem0r.spawnercollectors.CustomEntityType;
+import me.bestem0r.spawnercollectors.SCPlugin;
+import me.bestem0r.spawnercollectors.collector.Collector;
+import me.bestem0r.spawnercollectors.collector.EntityCollector;
+import me.bestem0r.spawnercollectors.utils.SpawnerUtils;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+
+public class PlaceholderAPIExpansion extends PlaceholderExpansion {
+    private final SCPlugin plugin;
+
+    public PlaceholderAPIExpansion(SCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist(){
+        return true;
+    }
+
+    @Override
+    public boolean canRegister(){
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "spawnercollectors";
+    }
+
+    @Override
+    public String getAuthor() {
+        return "bestem0r";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.0";
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        // spawnercollectors_amount[_<entity-type>]
+        if (params.startsWith("amount")) {
+            Collector collector = SpawnerUtils.getCollector(this.plugin, player);
+
+            // global spawners amount
+            if (params.equals("amount")) {
+                int amount = 0;
+
+                for (EntityCollector entityCollector : collector.getCollectorEntities()) {
+                    amount += entityCollector.getSpawnerAmount();
+                }
+
+                return String.valueOf(amount);
+            }
+
+            // per-mob spawners amount
+            CustomEntityType entityType = new CustomEntityType(params.substring(7));
+            Optional<EntityCollector> entityCollector = collector.getCollectorEntities().stream().filter((c) -> c.getEntityType().name().equals(entityType.name())).findAny();
+
+            return entityCollector.map(value -> String.valueOf(value.getSpawnerAmount())).orElse("0");
+        }
+
+        // spawnercollectors_limit[_<entity-type>]
+        if (params.startsWith("limit")) {
+            // global max limit
+            if (params.equals("limit")) {
+                return String.valueOf(this.plugin.getMaxSpawners());
+            }
+
+            // per-mob permission limit
+            CustomEntityType entityType = new CustomEntityType(params.substring(6));
+            player.sendMessage(entityType.name());
+            return String.valueOf(SpawnerUtils.getMaxSpawners(player, entityType));
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/me/bestem0r/spawnercollectors/utils/SpawnerUtils.java
+++ b/src/main/java/me/bestem0r/spawnercollectors/utils/SpawnerUtils.java
@@ -142,4 +142,18 @@ public class SpawnerUtils {
                 .max()
                 .orElse(-1);
     }
+
+    public static int getMaxSpawners(OfflinePlayer player, CustomEntityType type) {
+        if (player == null || !player.isOnline()) {
+            return 0;
+        }
+        return player.getPlayer().getEffectivePermissions().stream()
+                .map(PermissionAttachmentInfo::getPermission)
+                .filter((s) -> s.startsWith("spawnercollectors.spawner." + type.name().toLowerCase() + "."))
+                .filter((s) -> s.length() > 26 + type.name().length() + 1)
+                .map((s) -> s.substring(26 + type.name().length() + 1))
+                .mapToInt(Integer::parseInt)
+                .max()
+                .orElse(0);
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 1.7.6
 description: Store mob spawners in a "cloud gui" instead of creating laggy spawner farms
 api-version: 1.13
 main: me.bestem0r.spawnercollectors.SCPlugin
-softdepend: [HeadDatabase, Essentials, CMI, AdvancedSpawners, MineableSpawners, SilkSpawners]
+softdepend: [HeadDatabase, Essentials, CMI, AdvancedSpawners, MineableSpawners, SilkSpawners, PlaceholderAPI]
 depend: [Vault]
 commands:
   sc:


### PR DESCRIPTION
Hello! I'm using this plugin and find it great for my server, specially the performance improvements by allowing players to setup virtual mob farms instead of stacking and killing hundred of mobs.
I wanted to make some custom items that would require to know some info about the amount and limit but noticed you don't have any placeholders yet. I hope this can be added!

`%spawnercollectors_amount_<entity-type>%`  for the amount of spawners the player has of a given type
`%spawnercollectors_amount%`  for the total amount of spawners the player has of all types

`%spawnercollectors_limit%`  for the max spawners a player may have as configured in the config.yml
`%spawnercollectors_limit_<entity-type>%`  for the max spawners of a given type a player may have as configured using permissions